### PR TITLE
Make `send-packet` synchronous instead of returning a future

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fork of A Clojure interface to Sentry.
 ## Usage
 
 ```clojure
-[org.clojars.hcarvalhoalves/raven-clj "1.5.0"]
+[org.clojars.hcarvalhoalves/raven-clj "1.8.0"]
 ```
 
 ### `capture`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.hcarvalhoalves/raven-clj "1.7.2"
+(defproject org.clojars.hcarvalhoalves/raven-clj "1.8.0"
   :description "Fork of Sentry clojure client"
   :url "http://github.com/hcarvalhoalves/raven-clj"
   :license {:name "Eclipse Public License"

--- a/src/raven_clj/core.clj
+++ b/src/raven_clj/core.clj
@@ -33,14 +33,13 @@
   (let [url    (make-sentry-url uri project-id)
         header (make-sentry-header timestamp key secret)
         data   (dissoc packet-info :uri :project-id :key :secret)]
-    (future
-      (http/post url
-                 {:insecure?        true
-                  :throw-exceptions true
-                  :headers          {"X-Sentry-Auth" header
-                                     "User-Agent"    raven-clj-version
-                                     "Content-Type"  "application/json"}
-                  :body             (json/generate-string data)}))))
+    (http/post url
+               {:insecure?        true
+                :throw-exceptions true
+                :headers          {"X-Sentry-Auth" header
+                                   "User-Agent"    raven-clj-version
+                                   "Content-Type"  "application/json"}
+                :body             (json/generate-string data)})))
 
 
 

--- a/test/raven_clj/core_test.clj
+++ b/test/raven_clj/core_test.clj
@@ -3,7 +3,8 @@
             [raven-clj.core :as c])
   (:import [java.sql Timestamp]
            [java.util Date]
-           (java.util.concurrent ExecutionException)))
+           (java.util.concurrent ExecutionException)
+           (clojure.lang ExceptionInfo)))
 
 (def example-dsn
   (str "https://"
@@ -73,8 +74,8 @@
        (facts "on status code > 299"
               (fact "should bubble up exception"
                     (try
-                      (deref (c/capture example-dsn {}))
+                      (c/capture example-dsn {})
                       (catch Exception e
-                        (type e))) => ExecutionException
+                        (type e))) => ExceptionInfo
                     (provided
                       (#'clj-http.core/request anything) => {:status 500}))))


### PR DESCRIPTION
So client code can wrap and handle errors as necessary.
